### PR TITLE
DS Classic Menu: Fix copy dlp/pictochat from Nand (#941)

### DIFF
--- a/quickmenu/arm7/source/main.c
+++ b/quickmenu/arm7/source/main.c
@@ -118,6 +118,10 @@ int main() {
 	u8 readCommand = readPowerManagement(4);
 	isDSLite = (readCommand & BIT(4) || readCommand & BIT(5) || readCommand & BIT(6) || readCommand & BIT(7));
 
+	for (int i = 0; i < 8; i++) {
+		*(u8*)(0x2FFFD00+i) = *(u8*)(0x4004D07-i);	// Get ConsoleID
+	}
+
 	fifoSendValue32(FIFO_USER_03, *SCFG_EXT);
 	fifoSendValue32(FIFO_USER_04, isDSLite);
 	fifoSendValue32(FIFO_USER_07, *(u16*)(0x4004700));
@@ -142,6 +146,10 @@ int main() {
 		if(fifoGetValue32(FIFO_USER_04) == 1) {
 			changeBacklightLevel();
 			fifoSendValue32(FIFO_USER_04, 0);
+		}
+		if (*(u32*)(0x2FFFD0C) == 0x454D4D43) {
+			sdmmc_nand_cid((u32*)0x2FFD7BC);	// Get eMMC CID
+			*(u32*)(0x2FFFD0C) = 0;
 		}
 		swiWaitForVBlank();
 	}

--- a/quickmenu/arm9/source/common/dsimenusettings.cpp
+++ b/quickmenu/arm9/source/common/dsimenusettings.cpp
@@ -270,7 +270,8 @@ DSiMenuPlusPlusSettings::TLanguage DSiMenuPlusPlusSettings::getGuiLanguage()
 {
     if (guiLanguage == ELangDefault)
     {
-        return (TLanguage)PersonalData->language;
+		extern bool useTwlCfg;
+        return (TLanguage)(useTwlCfg ? *(u8*)0x02000406 : PersonalData->language);
     }
     return (TLanguage)guiLanguage;
 }

--- a/quickmenu/arm9/source/main.cpp
+++ b/quickmenu/arm9/source/main.cpp
@@ -992,13 +992,13 @@ int main(int argc, char **argv) {
 					snprintf(srcPath, sizeof(srcPath), "nand:/title/00030005/484e45%x/content/00000000.app", regions[i]);
 					if (access(srcPath, F_OK) == 0)
 					{
+						snprintf(pictochatPath, sizeof(pictochatPath), "/_nds/pictochat.nds");
+						remove(pictochatPath);
+						fcopy(srcPath, pictochatPath);	// Copy from NAND
+						pictochatFound = true;
 						break;
 					}
 				}
-
-				snprintf(pictochatPath, sizeof(pictochatPath), "/_nds/pictochat.nds");
-				fcopy(srcPath, pictochatPath);	// Copy from NAND
-				pictochatFound = true;
 			}
 		}
 
@@ -1007,18 +1007,16 @@ int main(int argc, char **argv) {
 		if (!dlplayFound) {
 			for (int i = 0; i < 3; i++)
 			{
-				if (regions[i] == 0x43 || regions[i] == 0x4B)
-				{
-					snprintf(dlplayPath, sizeof(dlplayPath), "/title/00030005/484e44%x/content/00000000.app", regions[i]);
-				}
-				else
-				{
-					snprintf(dlplayPath, sizeof(dlplayPath), "/title/00030005/484e4441/content/00000001.app");
-				}
-				if (access(dlplayPath, F_OK) == 0)
-				{
+				snprintf(dlplayPath, sizeof(dlplayPath), "/title/00030005/484e44%x/content/00000000.app", regions[i]);
+				if (access(dlplayPath, F_OK) == 0) {
 					dlplayFound = true;
 					break;
+				} else if (regions[i] != 0x43 && regions[i] != 0x4B) {
+					snprintf(dlplayPath, sizeof(dlplayPath), "/title/00030005/484e4441/content/00000001.app");
+					if (access(dlplayPath, F_OK) == 0) {
+						dlplayFound = true;
+						break;
+					}
 				}
 			}
 		}
@@ -1030,23 +1028,24 @@ int main(int argc, char **argv) {
 			if (access("nand:/", F_OK) == 0) {
 				for (int i = 0; i < 3; i++)
 				{
-					if (regions[i] == 0x43 || regions[i] == 0x4B)
-					{
-						snprintf(srcPath, sizeof(srcPath), "nand:/title/00030005/484e44%x/content/00000000.app", regions[i]);
-					}
-					else
-					{
-						snprintf(srcPath, sizeof(srcPath), "nand:/title/00030005/484e4441/content/00000001.app");
-					}
-					if (access(srcPath, F_OK) == 0)
-					{
+					snprintf(srcPath, sizeof(srcPath), "nand:/title/00030005/484e44%x/content/00000000.app", regions[i]);
+					if (access(srcPath, F_OK) == 0) {
+						snprintf(dlplayPath, sizeof(dlplayPath), "/_nds/dlplay.nds");
+						remove(dlplayPath);
+						fcopy(srcPath, dlplayPath);	// Copy from NAND
+						dlplayFound = true;
 						break;
+					} else if (regions[i] != 0x43 && regions[i] != 0x4B) {
+						snprintf(srcPath, sizeof(srcPath), "nand:/title/00030005/484e4441/content/00000001.app");
+						if (access(srcPath, F_OK) == 0) {
+							snprintf(dlplayPath, sizeof(dlplayPath), "/_nds/dlplay.nds");
+							remove(dlplayPath);
+							fcopy(srcPath, dlplayPath);	// Copy from NAND
+							dlplayFound = true;
+							break;
+						}
 					}
 				}
-
-				snprintf(dlplayPath, sizeof(dlplayPath), "/_nds/dlplay.nds");
-				fcopy(srcPath, dlplayPath);	// Copy from NAND
-				dlplayFound = true;
 			}
 		}
 		if (!dlplayFound && consoleModel >= 2) {


### PR DESCRIPTION
* DS Classic Menu: Bug Fix

Now copy dlp and pictochat from Nand should works fine on all region/version of DSi console.

* Add missing arm7 code for Nand access

* DS Classic Menu: Use twlCfg for getGuilanguage

<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

_Tell us what you've changed._

#### Where have you tested it?

_Tell us where have you tested it._

*** 
#### Pull Request status
- [ ]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
